### PR TITLE
fix: add-headers-to-subgraph-fetch-query-and-update-example-env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/greenlucid/legacy-curate-xdai
+SUBGRAPH_URL=https://api.studio.thegraph.com/query/61738/legacy-curate-gnosis/version/latest
 MAIN_LIST_ADDRESS=0x2442D40B0aeCad0298C2724A97F2f1BbDF2C2615
 CLASSIC_VIEW=0x27BC296DC0b8a6c3cD39326aE9EC14604e96f7BF
 LIGHT_VIEW=0xB32e38B08FcC7b7610490f764b0F9bFd754dCE53
@@ -7,7 +7,7 @@ CHAIN_ID=100
 NETWORK_NAME=Gnosis
 CURRENCY_NAME=xDAI
 GTCR_UI_URL=https://curate.kleros.io
-IPFS_GATEWAY=https://ipfs.kleros.io/
+IPFS_GATEWAY=https://cdn.kleros.link
 TWITTER_CONSUMER_KEY=flane
 TWITTER_CONSUMER_SECRET=flane
 TWITTER_ACCESS_TOKEN=flane

--- a/src/get-events.ts
+++ b/src/get-events.ts
@@ -564,6 +564,9 @@ const getEvents = async (
   const response = await fetch(config.SUBGRAPH_URL, {
     method: "POST",
     body: JSON.stringify({ query: fullQuery }),
+    headers: {
+      'Content-Type': 'application/json',
+    }
   })
 
   const { data } = (await response.json()) as any

--- a/src/utils/main-list-filter.ts
+++ b/src/utils/main-list-filter.ts
@@ -32,6 +32,9 @@ const getIncluderList = async (tcr: string) => {
   const response = (await fetch(config.SUBGRAPH_URL, {
     method: "POST",
     body: JSON.stringify(subgraphQuery),
+    headers: {
+      'Content-Type': 'application/json',
+    }
   })) as any
 
   const { data } = (await response.json()) as any


### PR DESCRIPTION
- updates the headers for subgraph fetch query
- updates example env variables